### PR TITLE
README 内の UPM パッケージ名を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ upm経由でインストールする場合は `https://github.com/ina-amagami/un
 ```manifest.json
 {
   "dependencies": {
-    "jp.amagamina.unity-overwriter": "https://github.com/ina-amagami/unity-overwriter.git"
+    "jp.amagamina.overwriter": "https://github.com/ina-amagami/unity-overwriter.git"
   }
 }
 ```


### PR DESCRIPTION
README に記述されている UPM インストール時のパッケージ名が package.json のものと異なっているため、以下のようなエラーが発生します。
そのため、README の記述を変更しました。

![image](https://user-images.githubusercontent.com/4415085/163082458-0ec62522-02fb-406d-834e-afc6044ebdb1.png)
